### PR TITLE
fix: adds custom number of maximum retries

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -6,6 +6,7 @@ const DEADLINE_MINUTES = parseInt(process.env.DEADLINE_MINUTES) || 15 // Default
 const LOG_IN_MESSAGE =
   'I confirm that I am the sole owner of this wallet address and no other person or entity has access to it. Any transactions that take place under this account are my responsibility and not that of any other. By signing this, I agree to engage in the use of CollarNetworks Marketmaker Bot and I understand that I am responsible for any losses that may occur as a result of my actions.'
 const RPC_URL = process.env.RPC_URL
+const MAX_RETRIES = process.env.MAX_RETRIES || 3
 module.exports = {
   RPC_URL,
   API_BASE_URL,

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const {
   PROVIDER_ADDRESS,
   POLL_INTERVAL_MS,
   RPC_URL,
+  MAX_RETRIES,
 } = require('./constants')
 
 if (!API_BASE_URL || !PROVIDER_ADDRESS) {
@@ -68,7 +69,7 @@ async function processOfferRequests() {
         const providerProposals = getProposalsByProvider(offer)
         if (
           providerProposals.length > 0 ||
-          (tries[offer.id] !== undefined && tries[offer.id] >= 2)
+          (tries[offer.id] !== undefined && tries[offer.id] >= MAX_RETRIES)
         ) {
           // skip these as they failed twice already
           continue


### PR DESCRIPTION
adds a maximum number of retries before skipping callstrike proposals -- this before was in a constant spiral and clogging up express api logs since it was happening constantly.